### PR TITLE
Added /dev/tty.wchusbserial* to arduino_serial_port_globs

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -56,7 +56,8 @@ function! arduino#InitializeConfig()
     let g:arduino_serial_port_globs = ['/dev/ttyACM*',
                                       \'/dev/ttyUSB*',
                                       \'/dev/tty.usbmodem*',
-                                      \'/dev/tty.usbserial*']
+                                      \'/dev/tty.usbserial*',
+                                      \'/dev/tty.wchusbserial*']
   endif
 endfunction
 


### PR DESCRIPTION
This is the file pattern for my serial ports. Without this, I can select it directly via :ArduinoChoosePort (or whatever the command is, I can't remember exactly).