### PR TITLE
Arduino IDE 1.8 can't work with relative paths, expand to full path

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -111,7 +111,7 @@ function! arduino#GetArduinoCommand(cmd)
   if !empty(g:arduino_programmer)
     let cmd = cmd . " --pref programmer=" . g:arduino_programmer
   endif
-  let cmd = cmd . " " . g:arduino_args . " " . expand('%')
+  let cmd = cmd . " " . g:arduino_args . " " . expand('%:p')
   return cmd
 endfunction
 


### PR DESCRIPTION
Arduino IDE 1.8 can't understand relative paths. If you change dir to your project and open test.ino in vim - expand('%') will return test.ino. expand('%:p') return full path to opened file.