### PR TITLE
Better compatibility to Android IDE local packages installation

### DIFF
--- a/doc/arduino.txt
+++ b/doc/arduino.txt
@@ -35,6 +35,7 @@ Overview:~
   |arduino_serial_tmux|..........Tmux command to open serial debugger.
   |arduino_serial_port|..........Location of the serial port.
   |arduino_serial_port_globs|....Globs to auto-search for serial port.
+  |arduino_user_installation|....Use user installation of arduino ide.
 
 -------------------------------------------------------------------------------
 Detailed descriptions and default values:~
@@ -109,6 +110,13 @@ Search these patterns to find a likely serial port to upload to. >
                                     \'/dev/tty.usbmodem*',
                                     \'/dev/tty.usbserial*']
 <
+
+                                               *'g:arduino_user_installation'*
+Set this variable to 1 if you want to use the the arduino user folder normally
+located under ~/.arduino15.
+If you're using a non default path you also have to set 'g:arduino_dir'. >
+  let g:arduino_user_installation = 0
+ 
 
 ===============================================================================
 COMMANDS                                                     *arduino-commands*


### PR DESCRIPTION
Hi,
I've create a patch to be able to use my ~/.arduino15 installation directory from the arduino ide.
Without that I wasn't able to retrieve the boards I've installed with my normal user and the actual ide 1.8.x into my user home folder.

I hope you're going to include that into the mainstream :)