### PR TITLE
Feature: Use tmux splits for verify and upload

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -51,6 +51,12 @@ function! arduino#InitializeConfig() abort
   if !exists('g:arduino_serial_tmux')
     let g:arduino_serial_tmux = 'split-window -d'
   endif
+  if !exists('g:arduino_upload_tmux')
+    let g:arduino_upload_tmux = 'split-window -d -p20'
+  endif
+  if !exists('g:arduino_verify_tmux')
+    let g:arduino_verify_tmux = 'split-window -d -p20'
+  endif
   if !exists('g:arduino_run_headless')
     let g:arduino_run_headless = executable('Xvfb') ? 1 : 0
   endif
@@ -335,13 +341,23 @@ endfunction
 
 function! arduino#Verify() abort
   let cmd = arduino#GetArduinoCommand("--verify")
-  exe s:TERM . cmd
+  if !empty($TMUX) && !empty(g:arduino_verify_tmux)
+    " the call to $SHELL -i is to prevent the split to directly close after the command has finished
+    exe "silent exec \"!tmux " . g:arduino_verify_tmux . " '" . cmd . "; $SHELL -i'\""
+  else
+    exe s:TERM . cmd
+  endif
   return v:shell_error
 endfunction
 
 function! arduino#Upload() abort
   let cmd = arduino#GetArduinoCommand("--upload")
-  exe s:TERM . cmd
+  if !empty($TMUX) && !empty(g:arduino_upload_tmux)
+    " the call to $SHELL -i is to prevent the split to directly close after the command has finished
+    exe "silent exec \"!tmux " . g:arduino_upload_tmux . " '" . cmd . "; $SHELL -i'\""
+  else
+    exe s:TERM . cmd
+  endif
   return v:shell_error
 endfunction
 

--- a/doc/arduino.txt
+++ b/doc/arduino.txt
@@ -34,6 +34,8 @@ Overview:~
   |arduino_serial_baud|..........The baud rate for the serial connection.
   |arduino_auto_baud|............Auto-detect the baud rate.
   |arduino_serial_tmux|..........Tmux command to open serial debugger.
+  |arduino_verify_tmux|..........Tmux command to open arduino verify cmd.
+  |arduino_upload_tmux|..........Tmux command to open arduino upload cmd.
   |arduino_serial_port|..........Location of the serial port.
   |arduino_serial_port_globs|....Globs to auto-search for serial port.
 
@@ -101,6 +103,20 @@ If inside a tmux session, run the serial connection command inside of this
 tmux command.  Set to '' to disable. The default will create a horizontal
 split. >
   let g:arduino_serial_tmux = 'split-window -d'
+<
+
+                                                     *'g:arduino_verify_tmux'*
+If inside a tmux session, run the arduino verify command inside of this
+tmux command.  Set to '' to disable. The default will create a horizontal
+split with a height of 20%. >
+  let g:arduino_verify_tmux = 'split-window -d -p20'
+<
+
+                                                     *'g:arduino_upload_tmux'*
+If inside a tmux session, run the arduino upload command inside of this
+tmux command.  Set to '' to disable. The default will create a horizontal
+split with a height of 20%. >
+  let g:arduino_upload_tmux = 'split-window -d -p20'
 <
 
                                                      *'g:arduino_serial_port'*

--- a/doc/tags
+++ b/doc/tags
@@ -11,6 +11,8 @@
 'g:arduino_serial_port'	arduino.txt	/*'g:arduino_serial_port'*
 'g:arduino_serial_port_globs'	arduino.txt	/*'g:arduino_serial_port_globs'*
 'g:arduino_serial_tmux'	arduino.txt	/*'g:arduino_serial_tmux'*
+'g:arduino_verify_tmux'	arduino.txt	/*'g:arduino_verify_tmux'*
+'g:arduino_upload_tmux'	arduino.txt	/*'g:arduino_upload_tmux'*
 'vim-arduino'	arduino.txt	/*'vim-arduino'*
 :ArduinoChooseBoard	arduino.txt	/*:ArduinoChooseBoard*
 :ArduinoChoosePort	arduino.txt	/*:ArduinoChoosePort*


### PR DESCRIPTION
I thought it a good idea to handle arduino --verify and arduino --upload similar to the serial command, as in my opinion tmux splits are way better to handle separate processes than vim splits are.

I implemented it similar to the serial command with variables to set (and disable the behaviour).
Only difference is the usage of silent to have no output in vim at all , as there is no meaningful anyway when using the tmux command.

Besides, thank you for the great plugin!