### PR TITLE
Feature: Added option for a build.path

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -112,7 +112,7 @@ function! arduino#GetBuildPath() abort
   endif
   let l:path = g:arduino_build_path
   let l:path = substitute(l:path, '{file}', expand('%:p'), 'g')
-  let l:path = substitute(l:path, '{project_dir}', fnamemodify(expand('%:p'), ":h"), 'g')
+  let l:path = substitute(l:path, '{project_dir}', expand('%:p:h'), 'g')
   return l:path
 endfunction
 

--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -42,6 +42,10 @@ function! arduino#InitializeConfig() abort
   if !exists('g:arduino_serial_cmd')
     let g:arduino_serial_cmd = 'screen {port} {baud}'
   endif
+  if !exists('g:arduino_build_path')
+    let g:arduino_build_path = '{project_dir}/build'
+  endif
+
   if !exists('g:arduino_serial_baud')
     let g:arduino_serial_baud = 9600
   endif
@@ -102,6 +106,17 @@ function! arduino#GetArduinoExecutable() abort
   endif
 endfunction
 
+function! arduino#GetBuildPath() abort 
+  if empty(g:arduino_build_path)
+    return ''
+  endif
+  let l:path = g:arduino_build_path
+  let l:path = substitute(l:path, '{file}', expand('%:p'), 'g')
+  let l:path = substitute(l:path, '{project_dir}', fnamemodify(expand('%:p'), ":h"), 'g')
+  return l:path
+endfunction
+
+
 function! arduino#GetArduinoCommand(cmd) abort
   let arduino = arduino#GetArduinoExecutable()
 
@@ -116,6 +131,10 @@ function! arduino#GetArduinoCommand(cmd) abort
   endif
   if !empty(g:arduino_programmer)
     let cmd = cmd . " --pref programmer=" . g:arduino_programmer
+  endif
+  let l:build_path = arduino#GetBuildPath()
+  if !empty(l:build_path)
+    let cmd = cmd . " --pref build.path=" . l:build_path
   endif
   let cmd = cmd . " " . g:arduino_args . " " . expand('%:p')
   return cmd

--- a/doc/arduino.txt
+++ b/doc/arduino.txt
@@ -26,6 +26,7 @@ Overview:~
   |arduino_cmd|..................Path to the arduino executable
   |arduino_dir|..................Path to the arduino install directory
   |arduino_home_dir|.............Path to the arduino user install directory
+  |arduino_build_path|...........Path to use for building the sketch
   |arduino_run_headless|.........Try to run inside Xvfb
   |arduino_args|.................Additional args to pass to 'arduino' command.
   |arduino_board|................The fully-qualified name of the board.
@@ -57,6 +58,18 @@ detect it, but if it cannot you can set the value manually. >
 The path to your user's 'arduino' data directory. Usually vim-arduino will be
 able to detect it, but if it cannot you can set the value manually. >
   let g:arduino_home_dir = $HOME . ".arduino15"
+<
+
+                                                        *'g:arduino_build_path'*
+The path where the sketch will be build and all intermediate object files will
+be placed. The final binary (.bin) can be found after building/verification in
+the folder.
+For a dynamic path you can following substitutions:
+ - {file} is substituted with the current sketch file (.ino)
+ - {project_dir} is substituted with the folder the sketch resides in
+Usage of a build path can be disabled with g:arduino_build_path = ''.
+If disabled, arduino ide chooses a temporary path and will do a full rebuild. >
+  let g:arduino_build_path = "{project_dir}/build"
 <
 
                                                     *'g:arduino_run_headless'*

--- a/doc/tags
+++ b/doc/tags
@@ -4,6 +4,7 @@
 'g:arduino_cmd'	arduino.txt	/*'g:arduino_cmd'*
 'g:arduino_dir'	arduino.txt	/*'g:arduino_dir'*
 'g:arduino_home_dir'	arduino.txt	/*'g:arduino_home_dir'*
+'g:arduino_build_path'	arduino.txt	/*'g:arduino_build_path'*
 'g:arduino_programmer'	arduino.txt	/*'g:arduino_programmer'*
 'g:arduino_run_headless'	arduino.txt	/*'g:arduino_run_headless'*
 'g:arduino_serial_baud'	arduino.txt	/*'g:arduino_serial_baud'*


### PR DESCRIPTION
If arduino ide is called without --pref build.path=path, it will always create a temporary directory.
This has two main disadvantages:

1. It will always do a full build, even if nothing has changed at all ( a real pain if the uploads fails a couple of times).
2. It will delete the temporary directory directly after the command finishes - no chance to inspect the binary or use it for manual upload with the esptool.

But arduino ide has an option to use a build.path resolving both issues.

I have added an option g:arduino_build_path and some logic in the GetArduinoCommand to add the --prefs build.path option to the arduino cmd. The build path has two substitutions for the filename ({file} => path/to/project/sketch.ino) and the project directory ({project_dir} => path/to/project).

However, there might arise the need for a ArduinoClean command to force a full rebuild of the project without any artefacts. How to do this properly does maybe require some discussion as a "rm -r build.path/*" might be a little to harsh... I'm open for any suggestion.

Cheers, Andrej