### PR TITLE
Added support for vim-slime for sending commands to tmux/screen/...

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -52,6 +52,9 @@ function! arduino#InitializeConfig() abort
   if !exists('g:arduino_auto_baud')
     let g:arduino_auto_baud = 1
   endif
+  if !exists('g:arduino_use_slime')
+    let g:arduino_use_slime = 0
+  endif
   if !exists('g:arduino_serial_tmux')
     let g:arduino_serial_tmux = 'split-window -d'
   endif
@@ -360,7 +363,9 @@ endfunction
 
 function! arduino#Verify() abort
   let cmd = arduino#GetArduinoCommand("--verify")
-  if !empty($TMUX) && !empty(g:arduino_verify_tmux)
+  if g:arduino_use_slime
+    call slime#send(cmd."\r")
+  elseif !empty($TMUX) && !empty(g:arduino_verify_tmux)
     " the call to $SHELL -i is to prevent the split to directly close after the command has finished
     exe "silent exec \"!tmux " . g:arduino_verify_tmux . " '" . cmd . "; $SHELL -i'\""
   else
@@ -371,7 +376,9 @@ endfunction
 
 function! arduino#Upload() abort
   let cmd = arduino#GetArduinoCommand("--upload")
-  if !empty($TMUX) && !empty(g:arduino_upload_tmux)
+  if g:arduino_use_slime
+    call slime#send(cmd."\r")
+  elseif !empty($TMUX) && !empty(g:arduino_upload_tmux)
     " the call to $SHELL -i is to prevent the split to directly close after the command has finished
     exe "silent exec \"!tmux " . g:arduino_upload_tmux . " '" . cmd . "; $SHELL -i'\""
   else
@@ -383,7 +390,9 @@ endfunction
 function! arduino#Serial() abort
   let cmd = arduino#GetSerialCmd()
   if empty(cmd) | return | endif
-  if !empty($TMUX) && !empty(g:arduino_serial_tmux)
+  if g:arduino_use_slime
+    call slime#send(cmd."\r")
+  elseif !empty($TMUX) && !empty(g:arduino_serial_tmux)
     exe s:TERM . "tmux " . g:arduino_serial_tmux . " '" . cmd . "'"
   else
     exe s:TERM . cmd

--- a/doc/arduino.txt
+++ b/doc/arduino.txt
@@ -34,6 +34,7 @@ Overview:~
   |arduino_serial_cmd|...........Command to run to attach to serial port.
   |arduino_serial_baud|..........The baud rate for the serial connection.
   |arduino_auto_baud|............Auto-detect the baud rate.
+  |arduino_use_slime|............Enables to use vim-slime for sending cmd to tmux.
   |arduino_serial_tmux|..........Tmux command to open serial debugger.
   |arduino_verify_tmux|..........Tmux command to open arduino verify cmd.
   |arduino_upload_tmux|..........Tmux command to open arduino upload cmd.
@@ -111,6 +112,11 @@ Automatically set the baud rate by searching for 'Serial.begin()' >
   let g:arduino_auto_baud = 1
 <
 
+                                                     *'g:arduino_use_slime'*
+Enables to use vim-slime to send the command to tmux/screen/... .
+See :help slime for configuration of slime. Disabled per default. >
+  let g:arduino_use_slime = 0
+<
                                                      *'g:arduino_serial_tmux'*
 If inside a tmux session, run the serial connection command inside of this
 tmux command.  Set to '' to disable. The default will create a horizontal

--- a/doc/tags
+++ b/doc/tags
@@ -14,6 +14,7 @@
 'g:arduino_serial_tmux'	arduino.txt	/*'g:arduino_serial_tmux'*
 'g:arduino_verify_tmux'	arduino.txt	/*'g:arduino_verify_tmux'*
 'g:arduino_upload_tmux'	arduino.txt	/*'g:arduino_upload_tmux'*
+'g:arduino_use_slime'	arduino.txt	/*'g:arduino_use_slime'*
 'vim-arduino'	arduino.txt	/*'vim-arduino'*
 :ArduinoChooseBoard	arduino.txt	/*:ArduinoChooseBoard*
 :ArduinoChoosePort	arduino.txt	/*:ArduinoChoosePort*


### PR DESCRIPTION
vim-slime is a nice vim plugin to send commands to tmux/screen/(a lot of other stuff).
As it is capable of sending cmd to existing panes, it is even more smooth for me than to create new splits on each verify/upload. 

Thus I enabled the usage of slime (optional with g:arduino_use_slime).