### PR TITLE
Tmux behavior, upload using "useprogrammer" and list programmers from path other than arduino home

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.vim]
+indent_style = space
+indent_size = 2
+charset = utf-8

--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -290,7 +290,7 @@ function! arduino#GetProgrammers() abort
       let package = pieces[-5]
     else
       let package = pieces[-3]
-      continue
+      " continue
     endif
     let lines = readfile(filename)
     for line in lines

--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -58,6 +58,9 @@ function! arduino#InitializeConfig() abort
   if !exists('g:arduino_use_tmux_pane_title')
     let g:arduino_use_tmux_pane_title = 0
   endif
+  if !exists('g:arduino_upload_using_programmer')
+    let g:arduino_upload_using_programmer = 0 
+  endif
 
   if g:arduino_use_tmux_pane_title == 1
     if !exists('g:arduino_serial_tmux')
@@ -289,7 +292,6 @@ function! arduino#GetProgrammers() abort
       let package = pieces[-5]
     else
       let package = pieces[-3]
-      " continue
     endif
     let lines = readfile(filename)
     for line in lines
@@ -425,7 +427,6 @@ function! arduino#Verify() abort
   if g:arduino_use_slime
     call slime#send(cmd."\r")
   elseif !empty($TMUX) && !empty(g:arduino_verify_tmux)
-    " the call to $SHELL -i is to prevent the split to directly close after the command has finished
     call arduino#TmuxRunCommand(g:arduino_verify_tmux, cmd, get(g:, 'arduino_verify_tmux_pane_title', -1))
   else
     exe s:TERM . cmd
@@ -434,25 +435,15 @@ function! arduino#Verify() abort
 endfunction
 
 function! arduino#Upload() abort
-  let cmd = arduino#GetArduinoCommand("--upload")
-  if g:arduino_use_slime
-    call slime#send(cmd."\r")
-  elseif !empty($TMUX) && !empty(g:arduino_upload_tmux)
-    " the call to $SHELL -i is to prevent the split to directly close after the command has finished
-    call arduino#TmuxRunCommand(g:arduino_upload_tmux, cmd, get(g:, 'arduino_upload_tmux_pane_title', -1))
+  if g:arduino_upload_using_programmer 
+    let cmd_options = "--upload --useprogrammer"
   else
-    exe s:TERM . cmd
+    let cmd_options = "--upload"
   endif
-  return v:shell_error
-endfunction
-
-
-function! arduino#UploadUsingProgrammer() abort
-  let cmd = arduino#GetArduinoCommand("--upload --useprogrammer")
+  let cmd = arduino#GetArduinoCommand(cmd_options)
   if g:arduino_use_slime
     call slime#send(cmd."\r")
   elseif !empty($TMUX) && !empty(g:arduino_upload_tmux)
-    " the call to $SHELL -i is to prevent the split to directly close after the command has finished
     call arduino#TmuxRunCommand(g:arduino_upload_tmux, cmd, get(g:, 'arduino_upload_tmux_pane_title', -1))
   else
     exe s:TERM . cmd

--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -3,7 +3,7 @@ if (exists('g:loaded_arduino_autoload') && g:loaded_arduino_autoload)
 endif
 let g:loaded_arduino_autoload = 1
 if has('win64') || has('win32') || has('win16')
-  echo "vim-arduino does not support windows :("
+  echoerr "vim-arduino does not support windows :("
   finish
 endif
 let s:HERE = resolve(expand('<sfile>:p:h:h'))
@@ -55,14 +55,39 @@ function! arduino#InitializeConfig() abort
   if !exists('g:arduino_use_slime')
     let g:arduino_use_slime = 0
   endif
-  if !exists('g:arduino_serial_tmux')
-    let g:arduino_serial_tmux = 'split-window -d'
+  if !exists('g:arduino_use_tmux_pane_title')
+    let g:arduino_use_tmux_pane_title = 0
   endif
-  if !exists('g:arduino_upload_tmux')
-    let g:arduino_upload_tmux = 'split-window -d -p20'
-  endif
-  if !exists('g:arduino_verify_tmux')
-    let g:arduino_verify_tmux = 'split-window -d -p20'
+
+  if g:arduino_use_tmux_pane_title == 1
+    if !exists('g:arduino_serial_tmux')
+      let g:arduino_serial_tmux = 'split-window -h'
+    endif
+    if !exists('g:arduino_upload_tmux')
+      let g:arduino_upload_tmux = 'split-window -v -p20'
+    endif
+    if !exists('g:arduino_verify_tmux')
+      let g:arduino_verify_tmux = 'split-window -v -p20'
+    endif
+    if !exists('g:arduino_serial_tmux_pane_title')
+      let g:arduino_serial_tmux_pane_title = 'arduino-tmux-serial-pane'
+    endif
+    if !exists('g:arduino_upload_tmux_pane_title')
+      let g:arduino_upload_tmux_pane_title = 'arduino-tmux-upload-pane'
+    endif
+    if !exists('g:arduino_verify_tmux_pane_title')
+      let g:arduino_verify_tmux_pane_title = 'arduino-tmux-upload-pane'
+    endif
+  else
+    if !exists('g:arduino_serial_tmux')
+      let g:arduino_serial_tmux = 'split-window -d'
+    endif
+    if !exists('g:arduino_upload_tmux')
+      let g:arduino_upload_tmux = 'split-window -d -p20'
+    endif
+    if !exists('g:arduino_verify_tmux')
+      let g:arduino_verify_tmux = 'split-window -d -p20'
+    endif
   endif
   if !exists('g:arduino_run_headless')
     let g:arduino_run_headless = executable('Xvfb') ? 1 : 0
@@ -98,6 +123,41 @@ function! arduino#SaveCache() abort
   call writefile(lines, s:cache)
 endfunction
 
+" Tmux helpers {{{1
+" Rum tmux command. If pane with passed title exists in tmux
+" session, function do not spawn new pane but send command to it.
+function! arduino#TmuxRunCommand(splitCommand, command, ...) abort
+  let paneTitle = get(a:, 1, -1)
+  let currentPaneId = system("tmux display-message -p '#{pane_id}'")
+  echom paneTitle
+  if paneTitle == -1
+    " Support for old style of tmux pane open
+    exec "silent exec \"!tmux ".a:splitCommand." '".a:command."; $SHELL -i'\""
+  else
+    let paneId = arduino#TmuxFindPane(paneTitle)
+    if paneId != -1
+      exec "silent exec \"!tmux send-keys -t \\\\%".paneId." '".a:command."' C-m\""
+    else
+      exec "silent exec \"!tmux ".a:splitCommand." 'tmux select-pane -T ".paneTitle."; ".a:command."; $SHELL -i'\""
+    endif
+  endif
+  " back to pane with vim
+  exec "silent exec \"!tmux select-pane -t \\\\".currentPaneId."\""
+endfunction
+
+" Search for tmux pane id by pane title.
+" If pane is not found, return -1
+function! arduino#TmuxFindPane(title) abort
+  let panesList = split(system("tmux list-panes -a -F '#{pane_title}:#{pane_id}'"), "\n")
+  for paneEntry in panesList
+    let [_paneTitle, _paneId] = split(paneEntry,':')
+    if _paneTitle == a:title
+      return _paneId[1:]
+    endif
+  endfor
+  return -1
+endfunction
+
 " Arduino command helpers {{{1
 function! arduino#GetArduinoExecutable() abort
   if exists('g:arduino_cmd')
@@ -109,7 +169,7 @@ function! arduino#GetArduinoExecutable() abort
   endif
 endfunction
 
-function! arduino#GetBuildPath() abort 
+function! arduino#GetBuildPath() abort
   if empty(g:arduino_build_path)
     return ''
   endif
@@ -367,7 +427,7 @@ function! arduino#Verify() abort
     call slime#send(cmd."\r")
   elseif !empty($TMUX) && !empty(g:arduino_verify_tmux)
     " the call to $SHELL -i is to prevent the split to directly close after the command has finished
-    exe "silent exec \"!tmux " . g:arduino_verify_tmux . " '" . cmd . "; $SHELL -i'\""
+    call arduino#TmuxRunCommand(g:arduino_verify_tmux, cmd, get(g:, 'arduino_verify_tmux_pane_title', -1))
   else
     exe s:TERM . cmd
   endif
@@ -380,7 +440,7 @@ function! arduino#Upload() abort
     call slime#send(cmd."\r")
   elseif !empty($TMUX) && !empty(g:arduino_upload_tmux)
     " the call to $SHELL -i is to prevent the split to directly close after the command has finished
-    exe "silent exec \"!tmux " . g:arduino_upload_tmux . " '" . cmd . "; $SHELL -i'\""
+    call arduino#TmuxRunCommand(g:arduino_upload_tmux, cmd, get(g:, 'arduino_upload_tmux_pane_title', -1))
   else
     exe s:TERM . cmd
   endif
@@ -393,7 +453,7 @@ function! arduino#Serial() abort
   if g:arduino_use_slime
     call slime#send(cmd."\r")
   elseif !empty($TMUX) && !empty(g:arduino_serial_tmux)
-    exe s:TERM . "tmux " . g:arduino_serial_tmux . " '" . cmd . "'"
+    call arduino#TmuxRunCommand(g:arduino_serial_tmux, cmd, get(g:, 'arduino_serial_tmux_pane_title', -1))
   else
     exe s:TERM . cmd
   endif

--- a/ftplugin/arduino.vim
+++ b/ftplugin/arduino.vim
@@ -21,6 +21,7 @@ command! -buffer -bar -nargs=? ArduinoChooseBoard call arduino#ChooseBoard(<f-ar
 command! -buffer -bar -nargs=? ArduinoChooseProgrammer call arduino#ChooseProgrammer(<f-args>)
 command! -buffer -bar ArduinoVerify call arduino#Verify()
 command! -buffer -bar ArduinoUpload call arduino#Upload()
+command! -buffer -bar ArduinoUploadUsingProgrammer call arduino#UploadUsingProgrammer()
 command! -buffer -bar ArduinoSerial call arduino#Serial()
 command! -buffer -bar ArduinoUploadAndSerial call arduino#UploadAndSerial()
 command! -buffer -bar ArduinoGetInfo call arduino#GetInfo()

--- a/ftplugin/arduino.vim
+++ b/ftplugin/arduino.vim
@@ -21,7 +21,6 @@ command! -buffer -bar -nargs=? ArduinoChooseBoard call arduino#ChooseBoard(<f-ar
 command! -buffer -bar -nargs=? ArduinoChooseProgrammer call arduino#ChooseProgrammer(<f-args>)
 command! -buffer -bar ArduinoVerify call arduino#Verify()
 command! -buffer -bar ArduinoUpload call arduino#Upload()
-command! -buffer -bar ArduinoUploadUsingProgrammer call arduino#UploadUsingProgrammer()
 command! -buffer -bar ArduinoSerial call arduino#Serial()
 command! -buffer -bar ArduinoUploadAndSerial call arduino#UploadAndSerial()
 command! -buffer -bar ArduinoGetInfo call arduino#GetInfo()


### PR DESCRIPTION
I've made some improvements around tmux behavior. Currently tmux spawn new pane per every run of upload/serial/verify command. After fix, script by default will spawn one pane for upload and verify command and one for serial. If script detect that target pane is currently opened, command will be sent to this pane using "send-keys". When command is done, focus backs to pane where (n)vim is located.
To enable this behavior set g:arduino_use_tmux_pane_title to 1. To customize how tmux pane should be opened see:
 - g:arduino_serial_tmux_pane_title,
 - g:arduino_upload_tmux_pane_title 
 - g:arduino_verify_tmux_pane_title.

PR also contains some small fixes around problems with list of available programmers from other that arduino home directory and add support for --useprogrammer option (see arduino#UploadUsingProgrammer)