### PR TITLE
Shebang changed to /usr/bin/env for more portability.

### DIFF
--- a/bin/run-headless
+++ b/bin/run-headless
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 # Wrapper script that will automatically use Xvfb to run a command
 declare -r XVFB="Xvfb :1 -nolisten tcp -screen :1 1280x800x24"
 


### PR DESCRIPTION
Hi, 

I tried to install your awesome plugin in a nix linux environment, where bash isn't at `/bin/bash` by default, as it is the case in other linux / bsd / unix variants. The suggestion would be to utilize `/usr/bin/env bash` instead, as for example suggested [here](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang).

