### PR TITLE
Upload direct to Arduino bootloader with arduino-cli 

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -191,7 +191,7 @@ function! arduino#GetCLICompileCommand(...) abort
   if !empty(port)
     let cmd = cmd . ' -p ' . port
   endif
-  if !empty(g:arduino_programmer)
+  if !empty(g:arduino_programmer) && g:arduino_upload_using_programmer
     let cmd = cmd . ' -P ' . g:arduino_programmer
   endif
   let l:build_path = arduino#GetBuildPath()


### PR DESCRIPTION
Upload direct to Arduino bootloader with arduino-cli when g:arduino_upload_using_programmer is false. Without this the plugin always attempts to program the Arduino via an external programmer.

Change tested on Manjaro Linux and Neovim 0.4.4.