### PR TITLE
use empty(port) instead of !port to check for empty string

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -565,7 +565,7 @@ endfunction
 
 function! arduino#GetSerialCmd() abort
   let port = arduino#GetPort()
-  if !port
+  if empty(port)
     echoerr "Error! No serial port found"
     return ''
   endif


### PR DESCRIPTION
I was getting this error message `Error! No serial port found` even when a port exists, seems the issue is with how it's checking for empty string.