### PR TITLE
Deliberate blocking UploadAndSerial() hack

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -600,7 +600,7 @@ function! arduino#Serial() abort
   call arduino#RunCmd(cmd)
 endfunction
 
-function! arduino#UploadAndSerial() abort
+function! arduino#UploadAndSerial()
   " Since 'terminal!' is non-blocking '!' must be used to provide this functionality
   let termBackup = s:TERM
   let s:TERM = '!'

--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -601,10 +601,14 @@ function! arduino#Serial() abort
 endfunction
 
 function! arduino#UploadAndSerial() abort
+  " Since 'terminal!' is non-blocking '!' must be used to provide this functionality
+  let termBackup = s:TERM
+  let s:TERM = '!'
   let ret = arduino#Upload()
   if ret == 0
     call arduino#Serial()
   endif
+  let s:TERM = termBackup
 endfunction
 
 " Serial helpers {{{2


### PR DESCRIPTION
Referencing Issue #52

2 possible considerations:
- Would it be better to get back to original terminal setting  before the call to Serial() ? 
- Could  an `abort` rising error prevent TERM from resetting ?