### PR TITLE
Added ArduinoSerial in README keybinds and remap others

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ can put them in `ftplugin/arduino.vim`:
 ```vim
 " Change these as desired
 nnoremap <buffer> <leader>aa <cmd>ArduinoAttach<CR>
-nnoremap <buffer> <leader>am <cmd>ArduinoVerify<CR>
+nnoremap <buffer> <leader>av <cmd>ArduinoVerify<CR>
 nnoremap <buffer> <leader>au <cmd>ArduinoUpload<CR>
-nnoremap <buffer> <leader>ad <cmd>ArduinoUploadAndSerial<CR>
+nnoremap <buffer> <leader>aus <cmd>ArduinoUploadAndSerial<CR>
+nnoremap <buffer> <leader>as <cmd>ArduinoSerial<CR>
 nnoremap <buffer> <leader>ab <cmd>ArduinoChooseBoard<CR>
 nnoremap <buffer> <leader>ap <cmd>ArduinoChooseProgrammer<CR>
 ```


### PR DESCRIPTION
I added a key mapping for the `:ArduinoSerial` command in the README and I changed the keybinds for `:ArduinoVerify` and `:ArduinoUploadAndSerial` because `am` and `ad` weren't really representative of what they we're doing.

If there was a reason for those keybinds just let me know and I'll change it back.