### PR TITLE
Add --libraries to compile step so we can incorporate libraries

### DIFF
--- a/autoload/arduino.vim
+++ b/autoload/arduino.vim
@@ -222,6 +222,7 @@ function! arduino#GetCLICompileCommand(...) abort
   if !empty(l:build_path)
     let cmd = cmd . ' --build-path "' . l:build_path . '"'
   endif
+  let cmd = cmd . ' --libraries "' . 'libraries' . '"'
   if a:0
     let cmd = cmd . ' ' . a:1
   endif


### PR DESCRIPTION
Should probably add a config option for the path but it appears to work if the directory doesn't exist anyway.